### PR TITLE
chore: add dependency installation step in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
+
+      - name: Install dependencies
+        run: npm ci
     
       - name: Build the project
         env:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change adds a step to install dependencies using `npm ci` before building the project.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R35-R37): Added a new step to install dependencies using `npm ci` before the build step.