### PR TITLE
fix: update environment variable for API URL in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
     
       - name: Build the project
         env:
-          VITE_TXT_SINK_API_URL: ${{ secrets.BASE_URL }}
+          VITE_TXT_SINK_API_URL: ${{ secrets.VITE_TXT_SINK_API_URL }}
         run: |
-          echo "VITE_TXT_SINK_API_URL=${{ secrets.BASE_URL }}" > .env.production
-          npm run build
+          echo "VITE_TXT_SINK_API_URL=${{ secrets.VITE_TXT_SINK_API_URL }}" > .env.production
+          npm run build -- --mode production
 
       - name: Upload to S3
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
This pull request includes a modification to the build process in the `.github/workflows/build.yml` file. The change updates the environment variable used for the `VITE_TXT_SINK_API_URL` to ensure it references the correct secret.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L40-R43): Updated the `VITE_TXT_SINK_API_URL` environment variable to use `${{ secrets.VITE_TXT_SINK_API_URL }}` instead of `${{ secrets.BASE_URL }}` and modified the build command to include `--mode production`.